### PR TITLE
feat(diagnostics): precise query redaction + capture field-completeness check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 本项目（HACS 自定义集成 `nio`）的版本更新记录，新版在上。
 
+## v0.4.4 — 2026-06-19
+
+诊断增强：精确脱敏 + 抓包字段完整性。
+
+**改进（诊断）**
+- 诊断包里的 status `query` 由**整条打码**改为**精确脱敏**：只盖 `sign` / `device_id` / `timestamp`，**保留 `field=` 列表与 `app_ver`**。部分传感器长期「未知」多半是抓包的 `field=` 不全（签名锁死、补不了字段），现在分享出来的诊断包能直接看出来。
+- 诊断包新增 `capture_fields`：`requested`（抓包请求了哪些段）+ `missing_critical`（缺了哪些关键段：exterior / soc / door / window / hvac / fota）—— 一眼区分「抓包字段不全 / 车离线 / 字段名不同」三种成因。
+- 调试子页说明追加：下载诊断后建议到 `github.com/genelee26/ha-nio/issues` 提 issue 并附文件，方便跟踪。
+
 ## v0.4.3 — 2026-06-18
 
 车卡布局整合 + 弹窗原生化 + 账单筛选。

--- a/custom_components/nio/__init__.py
+++ b/custom_components/nio/__init__.py
@@ -9,11 +9,12 @@ from homeassistant.components.frontend import add_extra_js_url
 from homeassistant.components.http import StaticPathConfig
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.loader import async_get_integration
 
 from .api import NioApiClient, NioOrdersClient
-from .capture import reconstruct_query_v1
+from .capture import missing_critical_fields, reconstruct_query_v1
 from .const import (
     CONF_MODEL,
     CONF_QUERY,
@@ -35,6 +36,30 @@ PLATFORMS: list[Platform] = [
     Platform.DEVICE_TRACKER,
     Platform.SENSOR,
 ]
+
+
+def _check_capture_completeness(hass: HomeAssistant, entry: NioConfigEntry) -> None:
+    """Raise/clear a repair issue if the capture omits critical field sections.
+
+    A narrow ``field=`` set is the usual cause of sensors stuck at "unknown":
+    the server only returns the sections the (sign-locked) query requested, so
+    the missing ones can never populate. Re-evaluated on every setup, so the
+    issue clears itself once a fuller capture is pasted.
+    """
+    issue_id = f"incomplete_capture_{entry.entry_id}"
+    missing = missing_critical_fields(entry.data.get(CONF_QUERY, ""))
+    if missing:
+        ir.async_create_issue(
+            hass,
+            DOMAIN,
+            issue_id,
+            is_fixable=False,
+            severity=ir.IssueSeverity.WARNING,
+            translation_key="incomplete_capture",
+            translation_placeholders={"fields": ", ".join(missing)},
+        )
+    else:
+        ir.async_delete_issue(hass, DOMAIN, issue_id)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: NioConfigEntry) -> bool:
@@ -78,6 +103,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: NioConfigEntry) -> bool:
     entry.runtime_data = NioRuntimeData(status=coordinator, orders=orders_coordinator)
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     entry.async_on_unload(entry.add_update_listener(_async_update_listener))
+    _check_capture_completeness(hass, entry)
     return True
 
 

--- a/custom_components/nio/capture.py
+++ b/custom_components/nio/capture.py
@@ -24,6 +24,7 @@ except ImportError:  # pragma: no cover - HA-free test imports it top-level
 # vehicle_id sits in the path: /api/2/rvs/vehicle/<id>/status
 _VEHICLE_ID_RE = re.compile(r"/vehicle/([^/?#]+)/status")
 _APP_VER_RE = re.compile(r"(?:^|&)app_ver=([^&]+)")
+_FIELD_RE = re.compile(r"(?:^|&)field=([^&]+)")
 
 
 def parse_capture(raw: str) -> tuple[str, str]:
@@ -68,6 +69,27 @@ def app_ver_from_query(query: str) -> str | None:
     """Pull ``app_ver`` out of a query string (for the matching User-Agent)."""
     match = _APP_VER_RE.search(query or "")
     return match.group(1) if match else None
+
+
+def query_fields(query: str) -> set[str]:
+    """The set of ``field=…`` sections a status query requests."""
+    return set(_FIELD_RE.findall(query or ""))
+
+
+def missing_critical_fields(query: str) -> list[str]:
+    """Critical sections (``const.CRITICAL_FIELDS``) the capture doesn't request.
+
+    The usual cause of sensors stuck at "unknown": the server only returns the
+    sections the (sign-locked) query asks for, so a capture from a lightweight
+    request can never populate door/window/hvac/fota/… Returned in
+    ``CRITICAL_FIELDS`` order. A query that selects *no* ``field=`` at all is
+    left alone — the server then returns its default (full) set, so flagging it
+    would be a false alarm.
+    """
+    present = query_fields(query)
+    if not present:
+        return []
+    return [f for f in const.CRITICAL_FIELDS if f not in present]
 
 
 def reconstruct_query_v1(data: dict) -> str:

--- a/custom_components/nio/const.py
+++ b/custom_components/nio/const.py
@@ -83,6 +83,14 @@ API_FIELDS = [
     "charge_status_order",
 ]
 
+# Status `field=` sections whose absence in a capture leaves the matching
+# sensors stuck at "unknown": the server only returns the sections the
+# (sign-locked) query asked for, so a capture taken from a lightweight request
+# can never populate them. Surfaced in diagnostics so users re-capture a full
+# request. Maps to: exterior_status, soc_status, door_status, window_status,
+# hvac_status, fota_status.
+CRITICAL_FIELDS = ("exterior", "soc", "door", "window", "hvac", "fota")
+
 # exterior_status.vehicle_state observed values
 VEHICLE_STATE_DRIVING = 1
 VEHICLE_STATE_PARKED = 2

--- a/custom_components/nio/diagnostics.py
+++ b/custom_components/nio/diagnostics.py
@@ -4,6 +4,12 @@ A redacted bundle to send to the developer when something looks off (especially
 with debug mode on): the last raw server responses (status + orders gateway),
 the normalized order ledger, and config/options with credentials masked. The
 debug-mode refresh buttons make sure these last responses are fresh first.
+
+The captured status ``query`` is masked **param-by-param** (not wholesale): the
+secret/identifying params (sign, device_id, timestamp) are hidden, but the
+field list and app_ver stay visible — a narrow ``field=`` set is the usual
+cause of sensors stuck at "unknown", and we want that clue to survive in a
+shared bundle. ``capture_fields`` spells the same thing out explicitly.
 """
 
 from __future__ import annotations
@@ -13,14 +19,18 @@ from typing import Any
 from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.core import HomeAssistant
 
+from .capture import missing_critical_fields, query_fields
 from .const import CONF_QUERY, CONF_TOKEN, CONF_VEHICLE_ID, OPT_DEBUG
 from .coordinator import NioConfigEntry, NioRuntimeData
 
+REDACTED = "**REDACTED**"
+
 # Credentials, per-vehicle identifiers and GPS are stripped from everything
-# echoed back, so the bundle is safe to share.
+# echoed back, so the bundle is safe to share. NOTE: CONF_QUERY is deliberately
+# absent — it's masked param-by-param (see ``_redact_query``) instead of
+# wholesale, to keep the diagnostically useful field=/app_ver visible.
 TO_REDACT = {
     CONF_TOKEN,
-    CONF_QUERY,
     CONF_VEHICLE_ID,
     "device_id",
     "sign",
@@ -31,18 +41,43 @@ TO_REDACT = {
     "latitude",
 }
 
+# Params hidden inside the status query string; everything else (field, app_ver,
+# region, app_id, lang) is kept.
+_QUERY_SECRET_PARAMS = {"sign", "device_id", "timestamp"}
+
+
+def _redact_query(query: str) -> str:
+    """Mask only the secret params in a status query; keep field=/app_ver/etc."""
+    out = []
+    for part in query.split("&"):
+        key, sep, _ = part.partition("=")
+        out.append(f"{key}={REDACTED}" if sep and key in _QUERY_SECRET_PARAMS else part)
+    return "&".join(out)
+
 
 async def async_get_config_entry_diagnostics(
     hass: HomeAssistant, entry: NioConfigEntry
 ) -> dict[str, Any]:
     """Return a redacted diagnostics bundle for the entry."""
+    entry_data = async_redact_data(dict(entry.data), TO_REDACT)
+    raw_query = entry.data.get(CONF_QUERY) or ""
+    if isinstance(entry_data.get(CONF_QUERY), str):
+        entry_data[CONF_QUERY] = _redact_query(entry_data[CONF_QUERY])
+
     diag: dict[str, Any] = {
         "entry": {
             "version": entry.version,
-            "data": async_redact_data(dict(entry.data), TO_REDACT),
+            "data": entry_data,
             "options": dict(entry.options),
         },
         "debug_enabled": bool(entry.options.get(OPT_DEBUG, False)),
+        # Which status sections the capture requests. A missing critical section
+        # can never populate (the sign-locked query can't be widened) → those
+        # sensors stay "unknown" until the user re-captures a fuller request.
+        "capture_fields": {
+            "requested": sorted(query_fields(raw_query)),
+            "missing_critical": missing_critical_fields(raw_query),
+        },
     }
 
     runtime = entry.runtime_data

--- a/custom_components/nio/manifest.json
+++ b/custom_components/nio/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/genelee26/ha-nio/issues",
   "requirements": [],
-  "version": "0.4.3"
+  "version": "0.4.4"
 }

--- a/custom_components/nio/strings.json
+++ b/custom_components/nio/strings.json
@@ -42,7 +42,7 @@
       },
       "debug": {
         "title": "Debug mode",
-        "description": "When on, injected debug orders show and count in the popup/sensors (never in long-term statistics), and the refresh buttons prompt to download diagnostics for the developer.",
+        "description": "When on, injected debug orders show and count in the popup/sensors (never in long-term statistics), and the refresh buttons prompt to download diagnostics for the developer. After downloading the diagnostics, please open an issue at github.com/genelee26/ha-nio/issues and attach the file so it can be tracked.",
         "data": { "debug": "Enable debug mode" }
       },
       "intervals": {
@@ -161,6 +161,12 @@
     "button": {
       "refresh": { "name": "Refresh data" },
       "refresh_orders": { "name": "Refresh service orders" }
+    }
+  },
+  "issues": {
+    "incomplete_capture": {
+      "title": "NIO capture is missing data fields",
+      "description": "The captured status request doesn't ask for these sections: {fields}. The matching sensors (doors, windows, lock, temperatures, firmware…) will stay \"unknown\" — the signature locks the request, so the missing sections can't be added. Fix: capture a status request from the vehicle's main page (pull-to-refresh) so it asks for the full field set, then update the credentials (NIO → Configure → Credentials) with the new capture."
     }
   }
 }

--- a/custom_components/nio/translations/en.json
+++ b/custom_components/nio/translations/en.json
@@ -42,7 +42,7 @@
       },
       "debug": {
         "title": "Debug mode",
-        "description": "When on, injected debug orders show and count in the popup/sensors (never in long-term statistics), and the refresh buttons prompt to download diagnostics for the developer.",
+        "description": "When on, injected debug orders show and count in the popup/sensors (never in long-term statistics), and the refresh buttons prompt to download diagnostics for the developer. After downloading the diagnostics, please open an issue at github.com/genelee26/ha-nio/issues and attach the file so it can be tracked.",
         "data": { "debug": "Enable debug mode" }
       },
       "intervals": {
@@ -161,6 +161,12 @@
     "button": {
       "refresh": { "name": "Refresh data" },
       "refresh_orders": { "name": "Refresh service orders" }
+    }
+  },
+  "issues": {
+    "incomplete_capture": {
+      "title": "NIO capture is missing data fields",
+      "description": "The captured status request doesn't ask for these sections: {fields}. The matching sensors (doors, windows, lock, temperatures, firmware…) will stay \"unknown\" — the signature locks the request, so the missing sections can't be added. Fix: capture a status request from the vehicle's main page (pull-to-refresh) so it asks for the full field set, then update the credentials (NIO → Configure → Credentials) with the new capture."
     }
   }
 }

--- a/custom_components/nio/translations/zh-Hans.json
+++ b/custom_components/nio/translations/zh-Hans.json
@@ -42,7 +42,7 @@
       },
       "debug": {
         "title": "调试模式",
-        "description": "开启后：注入的调试订单会在弹窗/传感器里显示并计数（但永不进入长期统计），刷新按钮会提示下载诊断发给开发者。",
+        "description": "开启后：注入的调试订单会在弹窗/传感器里显示并计数（但永不进入长期统计），刷新按钮会提示下载诊断发给开发者。下载诊断后，建议到 github.com/genelee26/ha-nio/issues 提一个 issue 并附上该文件，方便跟踪。",
         "data": { "debug": "启用调试模式" }
       },
       "intervals": {
@@ -161,6 +161,12 @@
     "button": {
       "refresh": { "name": "数据刷新" },
       "refresh_orders": { "name": "刷新服务订单" }
+    }
+  },
+  "issues": {
+    "incomplete_capture": {
+      "title": "NIO 抓包缺少数据字段",
+      "description": "捕获的 status 请求没有请求这些段：{fields}。对应的传感器（车门、车窗、车锁、温度、固件…）会一直显示「未知」——签名锁死了请求，缺的段补不进去。解决：从车辆主页下拉刷新时重新抓一条 status 请求（这样会请求完整字段集），再到 NIO → 配置 → 凭证 用新抓包更新。"
     }
   }
 }

--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -139,6 +139,32 @@ def test_reconstruct_defaults_when_missing():
     print("  v1 reconstruction defaults ✓")
 
 
+def test_query_fields():
+    assert capture.query_fields("field=soc&field=door&app_ver=6.6.0") == {"soc", "door"}
+    assert capture.query_fields("app_ver=6.3.0&sign=x") == set()  # no field= selection
+    # must not match a substring of another key
+    assert capture.query_fields("xfield=nope&field=hvac") == {"hvac"}
+    print("  field= set extraction ✓")
+
+
+def test_missing_critical_fields():
+    # A narrow capture (the usual "stuck unknown" cause): only exterior + soc.
+    narrow = "field=exterior&field=soc&app_ver=6.5.3&timestamp=1&sign=x"
+    assert capture.missing_critical_fields(narrow) == ["door", "window", "hvac", "fota"], (
+        capture.missing_critical_fields(narrow)
+    )
+    # A full capture requests every section -> nothing missing.
+    full = "&".join(f"field={f}" for f in const.API_FIELDS) + "&sign=x"
+    assert capture.missing_critical_fields(full) == [], capture.missing_critical_fields(full)
+    # No field= at all -> server returns its default (full) set; don't false-alarm.
+    assert capture.missing_critical_fields("app_ver=6.3.0&timestamp=1&sign=x") == []
+    # Returned in CRITICAL_FIELDS order, deterministically.
+    assert capture.missing_critical_fields("field=soc&sign=x") == [
+        f for f in const.CRITICAL_FIELDS if f != "soc"
+    ]
+    print("  missing critical fields (narrow/full/no-field/order) ✓")
+
+
 if __name__ == "__main__":
     for fn in (
         test_parse_full_url,
@@ -149,6 +175,8 @@ if __name__ == "__main__":
         test_app_ver_from_query,
         test_reconstruct_query_v1_matches_old_client,
         test_reconstruct_defaults_when_missing,
+        test_query_fields,
+        test_missing_critical_fields,
     ):
         print(f"{fn.__name__}:")
         fn()


### PR DESCRIPTION
- diagnostics: mask only sign/device_id/timestamp inside the status query
  (keep field=/app_ver visible) instead of wholesale-redacting it, and add
  `capture_fields` {requested, missing_critical}. A narrow field= set is the
  usual cause of sensors stuck at "unknown" and now survives in a shared bundle.
- capture: add query_fields() / missing_critical_fields() (HA-free, tested); a
  query with no field= selection is left alone (server returns its default set).
- repair issue `incomplete_capture` raised/cleared at setup when the capture
  omits critical sections (exterior/soc/door/window/hvac/fota).
- config "debug" step now suggests opening a GitHub issue with the diagnostics.
- bump 0.4.3 -> 0.4.4; CHANGELOG.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
